### PR TITLE
Changing the master and slave terminology

### DIFF
--- a/xbaydns/tests/initconftest.py
+++ b/xbaydns/tests/initconftest.py
@@ -106,8 +106,8 @@ class InitConfTest(basetest.BaseTestCase):
         log.debug("create tmpdir is:%s"%tmpdir)
         self.assertTrue( os.path.isdir("%s/%s/acl"%(tmpdir, sysconf.namedconf)) )
         self.assertTrue( os.path.isdir("%s/%s/dynamic"%(tmpdir, sysconf.namedconf)) )
-        self.assertTrue( os.path.isdir("%s/%s/master"%(tmpdir, sysconf.namedconf)) )
-        self.assertTrue( os.path.isdir("%s/%s/slave"%(tmpdir, sysconf.namedconf)) )
+        self.assertTrue( os.path.isdir("%s/%s/main"%(tmpdir, sysconf.namedconf)) )
+        self.assertTrue( os.path.isdir("%s/%s/subordinate"%(tmpdir, sysconf.namedconf)) )
         shutil.rmtree(tmpdir)
 
     def test_create_conf(self):

--- a/xbaydns/tests/namedconftest.py
+++ b/xbaydns/tests/namedconftest.py
@@ -72,11 +72,11 @@ class NamedConfTest(basetest.BaseTestCase):
         cmd = self.nc.addDomain(['sina.com.cn','mail.sina.com.cn'])
         self.assertEqual(cmd.replace("  ", "").replace("\n","").strip(),'''
                 zone "sina.com.cn" {
-                    type master;
+                    type main;
                     file "dynamic/internal.sina.com.cn.file";
                 };
                 zone "mail.sina.com.cn" {
-                    type master;
+                    type main;
                     file "dynamic/internal.mail.sina.com.cn.file";
                 };
                 '''.replace("  ", "").replace("\n","").strip())

--- a/xbaydns/tests/sysintergratetest.py
+++ b/xbaydns/tests/sysintergratetest.py
@@ -45,11 +45,11 @@ class SysIntergrate_ConfigInit_Test(basetest.BaseTestCase):
         self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"defaultzone.conf")))
         self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"acl")))
         self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"acl","acldef.conf")))
-        self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"master")))
-        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"master","empty.db")))
-        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"master","localhost-forward.db")))
-        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"master","localhost-reverse.db")))
-        self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"slave")))
+        self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"main")))
+        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"main","empty.db")))
+        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"main","localhost-forward.db")))
+        self.assertTrue(os.path.isfile(os.path.join(sysconf.chroot_path,sysconf.namedconf,"main","localhost-reverse.db")))
+        self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"subordinate")))
         self.assertTrue(os.path.isdir(os.path.join(sysconf.chroot_path,sysconf.namedconf,"dynamic")))
 
     def _add_default_conf(self):

--- a/xbaydns/tools/initconf.py
+++ b/xbaydns/tools/initconf.py
@@ -119,9 +119,9 @@ def create_destdir():
     os.makedirs("%s/%s/acl"%(tmpdir, sysconf.namedconf))
     os.makedirs("%s/%s/dynamic"%(tmpdir, sysconf.namedconf))
     os.chown("%s/%s/dynamic"%(tmpdir, sysconf.namedconf), sysconf.named_uid, 0)
-    os.mkdir("%s/%s/master"%(tmpdir, sysconf.namedconf))
-    os.mkdir("%s/%s/slave"%(tmpdir, sysconf.namedconf))
-    os.chown("%s/%s/slave"%(tmpdir, sysconf.namedconf), sysconf.named_uid, 0)
+    os.mkdir("%s/%s/main"%(tmpdir, sysconf.namedconf))
+    os.mkdir("%s/%s/subordinate"%(tmpdir, sysconf.namedconf))
+    os.chown("%s/%s/subordinate"%(tmpdir, sysconf.namedconf), sysconf.named_uid, 0)
     return tmpdir
 
 def create_conf(tmpdir):
@@ -142,9 +142,9 @@ def create_conf(tmpdir):
         tmpfile = open("%s/%s/named.root"%(tmpdir, sysconf.namedconf), "w")
         tmpfile.write(namedroot)
         tmpfile.close()
-        shutil.copyfile(TMPL_EMPTY_DB, "%s/%s/master/empty.db"%(tmpdir, sysconf.namedconf))
-        shutil.copyfile(TMPL_LOCALHOST_FORWARD_DB, "%s/%s/master/localhost-forward.db"%(tmpdir, sysconf.namedconf))
-        shutil.copyfile(TMPL_LOCALHOST_REVERSE_DB, "%s/%s/master/localhost-reverse.db"%(tmpdir, sysconf.namedconf))
+        shutil.copyfile(TMPL_EMPTY_DB, "%s/%s/main/empty.db"%(tmpdir, sysconf.namedconf))
+        shutil.copyfile(TMPL_LOCALHOST_FORWARD_DB, "%s/%s/main/localhost-forward.db"%(tmpdir, sysconf.namedconf))
+        shutil.copyfile(TMPL_LOCALHOST_REVERSE_DB, "%s/%s/main/localhost-reverse.db"%(tmpdir, sysconf.namedconf))
         shutil.copyfile(TMPL_RNDC_KEY, "%s/%s/rndc.key"%(tmpdir, sysconf.namedconf))
         os.chmod("%s/%s/rndc.key"%(tmpdir, sysconf.namedconf),0600)
         os.chown("%s/%s/rndc.key"%(tmpdir, sysconf.namedconf),sysconf.named_uid,0)
@@ -205,8 +205,8 @@ def main():
     log.debug(tmpdir)
     #清理旧世界
     shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"acl"),ignore_errors=True)
-    shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"master"),ignore_errors=True)
-    shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"slave"),ignore_errors=True)
+    shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"main"),ignore_errors=True)
+    shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"subordinate"),ignore_errors=True)
     shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"dynamic"),ignore_errors=True)
     shutil.rmtree(os.path.join(sysconf.chroot_path,sysconf.namedconf,"view"),ignore_errors=True)
     if create_conf(tmpdir) == False or install_conf(tmpdir, chrootdir) == False:

--- a/xbaydns/tools/namedconf.py
+++ b/xbaydns/tools/namedconf.py
@@ -134,7 +134,7 @@ key "%s" {
                 fname=self.getDomainFileName(d,view)
                 s='''
     zone "%(domain)s" {
-        type master;
+        type main;
         file "%(fname)s";
     };'''%{'domain':d,
            'fname':fname}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.